### PR TITLE
增加自定义键位

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ xiaohuihui1022的[展示视频](https://www.bilibili.com/video/BV1Hr421M7SL)和[
 ## 注意事项：
 Release中-1.4.0仅为备份版本，如果原作者的链接失效可以在这里下载汉化版。
 
-##
-
 ## 16K 键位：
 ASDFJKL;
 ZXCVBM./

--- a/README.md
+++ b/README.md
@@ -1,56 +1,13 @@
-# Adofai AutoCat 备份版本
-# 现在本软件无需手动设置延迟，只需要在第一格砖块时按下insert，即可自动打谱
-# 注意：
-## 本仓库为xiaohuihui1022汉化改版（兼容AngleData），原仓库已被Archived。
+# Adofai AutoCat V2
+本仓库为继xiaohuihui1022的~~加强~~版本。
 
-## Todo List:
-- [x] 支持识别angleData
-- [x] 修复大地、RTX 20000等非DLC谱子无法正常打完的问题
-- [x] 支持DLC内容
-- [ ] 手法模拟
-- [ ] 支持16K
-- [x] 自动校准
+xiaohuihui1022的[展示视频](https://www.bilibili.com/video/BV1Hr421M7SL)和[原仓库](https://github.com/xiaohuihui1022/Adofai_AutoCat)
+
+## 注意事项：
+Release中-1.4.0仅为备份版本，如果原作者的链接失效可以在这里下载汉化版。
+
+##
 
 ## 16K 键位：
 ASDFJKL;
 ZXCVBM./
-
-# 以下是原作者的README
-
-![ㅋㅋㅋㅋ](https://raw.githubusercontent.com/NoBrain0917/Adofai_AutoCat/master/img/%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B.png)<br>
-이새기뭐임ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ<br>
-
-# !개발중지 됨
-<br>
-
-![플레이](https://github.com/NoBrain0917/Adofai_AutoCat/blob/master/img/play.gif?raw=true)       
-얼불춤을 토끼가 아닌 고양이가 대신 쳐줍니다.    
-사용하고 싶으면 직접 빌드해서 쓰세요.    
-**※ 빌드 질문 안받습니다 모르겠으면 배우거나 쓰지마세요.**
-      
-위에 사진같은 일이 벌어져서 일부러 일부 코드를 망가트렸습니다.
-참고만 해주세요
-
-# Usage
-## Level Editor
-![메인](https://github.com/NoBrain0917/Adofai_AutoCat/blob/master/img/main.png?raw=true)    
-`파일 열기`를 눌러 파일을 선택할 수 있습니다.    
-
-## Steam Workshop
-![메인2](https://github.com/NoBrain0917/Adofai_AutoCat/blob/master/img/main2.png?raw=true)     
-창작마당에 있는 맵의 이름을 검색하시고 `엔터` 또는 `분석`을 누르시면 맵이 분석됩니다.           
-     
-          
-             
-
-`렉딜레이`는 맵이 로드되는 딜레이 입니다. 컴사양에따라 바뀔 수 있습니다. (기본 값 - 0)   
-`창작모드`을 활성화하면 창작마당 맵을 검색하실 수 있습니다.    
-`Insert`키를 누르면 토끼 대신 고양이가 치기 시작합니다.     
-끌려면 `Insert`키를 한번 더 눌러주세요.         
-
-
-# Warning
-- 이걸로 남에게 피해를 주는 행동을 하지 말아주세요.
-- 빌드된 파일을 커뮤니티나 사람 많은곳에 올리지 마세요.
-- 이걸로 깬 맵을 유튜브에 올리고 싶다면 매크로임을 밝혀주세요.
-- 걍 뿌리지 말고 너 혼자만 쓰세요.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 - [ ] 支持16K
 - [x] 自动校准
 
+## 16K 键位：
+ASDFJKL;
+ZXCVBM./
+
 # 以下是原作者的README
 
 ![ㅋㅋㅋㅋ](https://raw.githubusercontent.com/NoBrain0917/Adofai_AutoCat/master/img/%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B%E3%85%8B.png)<br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Adofai AutoCat V3
+# Adofai AutoCat 备份版本
 # 现在本软件无需手动设置延迟，只需要在第一格砖块时按下insert，即可自动打谱
 # 注意：
 ## 本仓库为xiaohuihui1022汉化改版（兼容AngleData），原仓库已被Archived。

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Adofai AutoCat
+# Adofai AutoCat V3
 # 现在本软件无需手动设置延迟，只需要在第一格砖块时按下insert，即可自动打谱
 # 注意：
-## 本仓库为我自己汉化改版（兼容AngleData），原仓库已被Archived。
+## 本仓库为xiaohuihui1022汉化改版（兼容AngleData），原仓库已被Archived。
 
 ## Todo List:
 - [x] 支持识别angleData
 - [x] 修复大地、RTX 20000等非DLC谱子无法正常打完的问题
 - [x] 支持DLC内容
 - [ ] 手法模拟
+- [ ] 支持16K
 - [x] 自动校准
 
 # 以下是原作者的README


### PR DESCRIPTION
我希望可以让用户更改程序在通过关卡时的键位以适配一些有键位限制的Mod。
另外，在通过一些高难度谱面（比如RTX20000）时可以考虑将按键（轮指）顺序改一下（假设用户设置的键位为12345678，现在的顺序是”54637281“，可以改成”43215678“（外轮）或者”12348765“（内轮））